### PR TITLE
Edit the DuckStation entry to be more accurate

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,17 +246,17 @@
 
 		        <div class="col-md-4 my-3" data-aos="zoom-in" data-aos-duration="400">
                     <div class="card text-center">
-                        <img class="card-img-top" src="./img/duckstation-uwp.png" alt="Duckstation">
+                        <img class="card-img-top" src="./img/duckstation-uwp.png" alt="DuckStation-UWP">
                         <div class="card-body">
                             <h5 class="card-title">
-                                DuckStation (NEW)
+                                DuckStation-UWP
                             </h5>
                             <p class="card-text">
-                                Standalone PlayStation Emulator, new port maintained by @vera on our Discord!
+                                Standalone PlayStation Emulator. An actively updated and maintained fork of DuckStation specifically for Xbox and UWP.
                             </p>
                             <div class="row justify-content-around">
                                 <a href="https://github.com/irixaligned/duckstation-uwp/releases/latest" class="col-md-4 mb-md-0 mb-3 btn btn-secondary bg-success">Download App</a>
-                                <a data-bs-toggle="modal" href="https://duckstation.org" class="col-md-4 btn btn-dark">Official Page</a>
+                                <a data-bs-toggle="modal" href="https://github.com/irixaligned/duckstation-uwp" class="col-md-4 btn btn-dark">Official Page</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
I would prefer to keep DuckStation-UWP, with the modifications done to the base emulator and the specific focus of the project, (decently) separate from DuckStation.

As compared to being a simple unmaintained patchset for it to just run on UWP platforms, it's more of an entire separate port with it's own set of modifications and such to make it an equal or better experience to play on Xbox and UWP platforms, and it's enough to at least get a separate name.

Also, this reads better and a certain person can't come crying that I'm (we're) using his name on something he has next to no involvement in.

Please feel free to reword/edit if you feel it is necessary.